### PR TITLE
remove extra / at the end of $base

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -384,7 +384,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
         $final = $base . $separator . implode($separator, $queryParts) . $fragment;
       }
       else {
-        $final = $base . '?' . implode($separator, $queryParts) . $fragment;
+        $final = untrailingslashit($base) . '?' . implode($separator, $queryParts) . $fragment;
       }
 
     }
@@ -400,7 +400,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       }
 
       if (!empty($queryParts)) {
-        $final = $base . '?' . implode($separator, $queryParts) . $fragment;
+        $final = untrailingslashit($base) . '?' . implode($separator, $queryParts) . $fragment;
       }
       else {
         $final = $base . $fragment;


### PR DESCRIPTION
If there is a query string with a trailing / then WordPress will redirect without the / and cause session to be dumped.

Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
